### PR TITLE
health: align /health-check/ with the external-monitoring spec

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -69,9 +69,11 @@ env = environ.Env(
     SESSION_COOKIE_DOMAIN=str,
     SESSION_COOKIE_AGE=(int, 1209600),  # seconds (Default: 2 weeks)
     CSRF_COOKIE_DOMAIN=str,
-    # Health check
-    HEALTH_CHECK_DISK_USAGE_MAX=(int, 95),  # in percentage
-    HEALTH_CHECK_DISK_MEMORY_MIN=(int, 100),  # in MB
+    # Health check (/health-check/ — external monitoring, distinct from /healthz probes)
+    # Read as strings so an empty value / "none" can disable a check (see below); default active.
+    HEALTH_CHECK_DISK_USAGE_MAX=(str, "80"),  # percent; empty/"none" -> disk check skipped
+    HEALTH_CHECK_MEMORY_MIN=(str, "100"),  # MB (toggles the memory check on); empty/"none" -> skipped
+    HEALTH_CHECK_SKIP_STORAGE=(bool, False),  # true -> drop the storage round-trip check
     # Misc
     TEMP_FILE_DIR=(str, "/tmp/"),
     RELEASE=(str, "develop"),
@@ -163,14 +165,16 @@ INSTALLED_APPS = [
     "allauth.headless",
     "allauth.socialaccount",
     "allauth.socialaccount.providers.google",
-    # - Health-check
+    # - Health-check: outward-facing /health-check/ endpoint for the external monitor
+    #   (distinct from the pod-internal /healthz probes). Each plugin is a Django app; only the
+    #   ones whose dependency this project actually has are enabled. health_check.storage is
+    #   appended conditionally below (HEALTH_CHECK_SKIP_STORAGE). No rabbitmq plugin (redis cache).
     "health_check",  # required
     "health_check.db",  # stock Django health checkers
     "health_check.cache",
-    "health_check.storage",
     "health_check.contrib.migrations",
-    "health_check.contrib.psutil",  # disk and memory utilization; requires psutil
-    "health_check.contrib.redis",  # requires Redis broker
+    "health_check.contrib.psutil",  # disk + memory (needs psutil)
+    "health_check.contrib.redis",  # redis cache is wired (REDIS_URL below)
     # Internal apps
     "apps.standup",
     "apps.user",
@@ -178,6 +182,12 @@ INSTALLED_APPS = [
     "apps.track",
     "apps.journal",
 ]
+
+# health_check.storage does a save/read/delete round-trip against the default storage backend
+# on every /health-check/ poll. Enabled by default; set HEALTH_CHECK_SKIP_STORAGE=true to omit it
+# where that round-trip is undesirable (e.g. a remote object store polled frequently).
+if not env("HEALTH_CHECK_SKIP_STORAGE"):
+    INSTALLED_APPS.append("health_check.storage")
 
 MIDDLEWARE = [
     # banjo_utils HealthProbeMiddleware serves pod-local /healthz/live/ and
@@ -536,11 +546,24 @@ GOOGLE_CALENDAR_INCLUDE_DEBUG_IN_EVENT = env("GOOGLE_CALENDAR_INCLUDE_DEBUG_IN_E
 BANJO_HEALTH_PROBE_LIVE_URL = "/healthz/live/"
 BANJO_HEALTH_PROBE_READY_URL = "/healthz/ready/"
 
+# django-health-check (/health-check/). health_check.contrib.redis connects to settings.REDIS_URL
+# (it defaults to localhost otherwise) — point it at the same redis the app already uses.
 REDIS_URL = DJANGO_CACHE_REDIS_URL
-HEALTHCHECK_CACHE_KEY = "alert_hub_healthcheck_key"
+HEALTHCHECK_CACHE_KEY = "app_healthcheck_key"
+
+
+def _health_check_threshold(env_key):
+    # Empty / "none" disables the corresponding psutil check (the plugin isn't registered);
+    # any other value is the numeric threshold. Lets each environment toggle it via env alone.
+    raw = typing.cast("str", env(env_key)).strip()
+    return None if raw.lower() in ("", "none") else int(raw)
+
+
 HEALTH_CHECK = {
-    "DISK_USAGE_MAX": env("HEALTH_CHECK_DISK_USAGE_MAX"),
-    "MEMORY_MIN": env("HEALTH_CHECK_DISK_MEMORY_MIN"),
+    # percent; None -> disk check skipped (env HEALTH_CHECK_DISK_USAGE_MAX)
+    "DISK_USAGE_MAX": _health_check_threshold("HEALTH_CHECK_DISK_USAGE_MAX"),
+    # MB toggle; None -> memory check skipped (env HEALTH_CHECK_MEMORY_MIN)
+    "MEMORY_MIN": _health_check_threshold("HEALTH_CHECK_MEMORY_MIN"),
 }
 
 # Slack

--- a/main/urls.py
+++ b/main/urls.py
@@ -17,8 +17,9 @@ admin.site.site_url = config.APP_FRONTEND_HOST.geturl()
 
 urlpatterns = [
     path("admin/", admin.site.urls, name="admin"),
+    # Outward-facing health endpoint for the external monitor (django-health-check).
+    # Distinct from the pod-internal /healthz/{live,ready} probes served by banjo middleware.
     path("health-check/", include("health_check.urls")),
-    # path('health-check/', include('health_check.urls')),
     path(
         "graphql/",
         # TODO: Remove this after updating the frontend to send csrf tokens

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,11 @@ dependencies = [
     "uwsgi",
     "aws-sns-message-validator",
     "google-api-python-client",
-    "django-health-check",
+    # NOTE: pinned to the latest 3.x; 4.x is a breaking async rewrite that drops the
+    # migrations/disk checks and the HEALTH_CHECK settings this project uses.
+    "django-health-check==3.24.0",
     "Pillow",
-    "psutil",
+    "psutil==7.2.2",
     "django-admin-rangefilter",
     "django-allauth[socialaccount]",
     "djangoql", # Admin panel query search

--- a/uv.lock
+++ b/uv.lock
@@ -443,14 +443,15 @@ wheels = [
 
 [[package]]
 name = "django-health-check"
-version = "3.18.3"
+version = "3.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
+    { name = "psutil" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/e9/0699ea3debfda75e5960ff99f56974136380e6f8202d453de7357e1f67fc/django_health_check-3.18.3.tar.gz", hash = "sha256:18b75daca4551c69a43f804f9e41e23f5f5fb9efd06cf6a313b3d5031bb87bd0", size = 20919, upload-time = "2024-06-22T14:34:32.627Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/a6/f474f443b0a7f9e7e52a25a3773a31c5c061bdb28cf311b7801fc250db9b/django_health_check-3.24.0.tar.gz", hash = "sha256:b5e01d2013a254cc5a2c7b19c62f11ea6fd2624c87a9d990e11a1b3874df78b5", size = 20807, upload-time = "2026-02-12T10:02:18.482Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/1e/3b23b580762cca7456427731de9b90718d15eec02ebe096437469d767dfe/django_health_check-3.18.3-py2.py3-none-any.whl", hash = "sha256:f5f58762b80bdf7b12fad724761993d6e83540f97e2c95c42978f187e452fa07", size = 30331, upload-time = "2024-06-22T14:34:30.184Z" },
+    { url = "https://files.pythonhosted.org/packages/38/17/51aabb4908e007accf3c596b92a62ed7e456c581a1e45f06e0f2219dc6c0/django_health_check-3.24.0-py3-none-any.whl", hash = "sha256:bd568d7d3813980668dfbe730214aef5da7c8da73bc2aa60ec2eeca8a3788da6", size = 37964, upload-time = "2026-02-12T10:02:17.08Z" },
 ]
 
 [[package]]
@@ -1089,17 +1090,24 @@ wheels = [
 
 [[package]]
 name = "psutil"
-version = "7.0.0"
+version = "7.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2a/80/336820c1ad9286a4ded7e845b2eccfcb27851ab8ac6abece774a6ff4d3de/psutil-7.0.0.tar.gz", hash = "sha256:7be9c3eba38beccb6495ea33afd982a44074b78f28c434a1f51cc07fd315c456", size = 497003, upload-time = "2025-02-13T21:54:07.946Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/e6/2d26234410f8b8abdbf891c9da62bee396583f713fb9f3325a4760875d22/psutil-7.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:101d71dc322e3cffd7cea0650b09b3d08b8e7c4109dd6809fe452dfd00e58b25", size = 238051, upload-time = "2025-02-13T21:54:12.36Z" },
-    { url = "https://files.pythonhosted.org/packages/04/8b/30f930733afe425e3cbfc0e1468a30a18942350c1a8816acfade80c005c4/psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:39db632f6bb862eeccf56660871433e111b6ea58f2caea825571951d4b6aa3da", size = 239535, upload-time = "2025-02-13T21:54:16.07Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/ed/d362e84620dd22876b55389248e522338ed1bf134a5edd3b8231d7207f6d/psutil-7.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fcee592b4c6f146991ca55919ea3d1f8926497a713ed7faaf8225e174581e91", size = 275004, upload-time = "2025-02-13T21:54:18.662Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/b9/b0eb3f3cbcb734d930fdf839431606844a825b23eaf9a6ab371edac8162c/psutil-7.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b1388a4f6875d7e2aff5c4ca1cc16c545ed41dd8bb596cefea80111db353a34", size = 277986, upload-time = "2025-02-13T21:54:21.811Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/a2/709e0fe2f093556c17fbafda93ac032257242cabcc7ff3369e2cb76a97aa/psutil-7.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5f098451abc2828f7dc6b58d44b532b22f2088f4999a937557b603ce72b1993", size = 279544, upload-time = "2025-02-13T21:54:24.68Z" },
-    { url = "https://files.pythonhosted.org/packages/50/e6/eecf58810b9d12e6427369784efe814a1eec0f492084ce8eb8f4d89d6d61/psutil-7.0.0-cp37-abi3-win32.whl", hash = "sha256:ba3fcef7523064a6c9da440fc4d6bd07da93ac726b5733c29027d7dc95b39d99", size = 241053, upload-time = "2025-02-13T21:54:34.31Z" },
-    { url = "https://files.pythonhosted.org/packages/50/1b/6921afe68c74868b4c9fa424dad3be35b095e16687989ebbb50ce4fceb7c/psutil-7.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:4cf3d4eb1aa9b348dec30105c55cd9b7d4629285735a102beb4441e38db90553", size = 244885, upload-time = "2025-02-13T21:54:37.486Z" },
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]
@@ -1526,7 +1534,7 @@ requires-dist = [
     { name = "django-allauth", extras = ["socialaccount"] },
     { name = "django-cors-headers" },
     { name = "django-environ" },
-    { name = "django-health-check" },
+    { name = "django-health-check", specifier = "==3.24.0" },
     { name = "django-premailer" },
     { name = "django-redis", specifier = ">=5.3.0,<6" },
     { name = "django-reversion" },
@@ -1539,7 +1547,7 @@ requires-dist = [
     { name = "google-api-python-client" },
     { name = "ipython" },
     { name = "pillow" },
-    { name = "psutil" },
+    { name = "psutil", specifier = "==7.2.2" },
     { name = "psycopg2-binary", specifier = ">=2.9,<3" },
     { name = "python-ulid" },
     { name = "pyyaml" },


### PR DESCRIPTION
Brings the existing \`django-health-check\` endpoint in line with the current
health-check conventions. \`/health-check/\` is the outward-facing endpoint an
external monitor polls — distinct from the pod-internal \`/healthz\` liveness/
readiness probes.

## Changes

- **Pin** \`django-health-check==3.24.0\` (latest 3.x) and \`psutil==7.2.2\`. 4.x is a
  breaking async rewrite that drops the migrations/disk checks and the
  \`HEALTH_CHECK\` settings this project relies on.
- **Env-skippable psutil thresholds** — \`HEALTH_CHECK_DISK_USAGE_MAX\` /
  \`HEALTH_CHECK_MEMORY_MIN\` are read as strings; an empty value or \`none\`
  un-registers that check. Defaults: 80% disk, 100 MB memory.
- **\`HEALTH_CHECK_SKIP_STORAGE\`** toggle to drop the storage save/read/delete
  round-trip where the default backend is a remote object store polled
  frequently. Enabled by default.
- Rename the mislabelled \`HEALTH_CHECK_DISK_MEMORY_MIN\` env var to
  \`HEALTH_CHECK_MEMORY_MIN\`, and use a project-neutral \`HEALTHCHECK_CACHE_KEY\`.
- Document that \`contrib.redis\` reads \`settings.REDIS_URL\` (pointed at the app's
  redis cache) and drop the stale duplicate url entry.

## Verification

- \`/health-check/\` → **200** with the full plugin list (db, cache, storage,
  migrations, disk, memory, redis).
- A downed dependency → **500** naming the failing backend.
- All three skip envs toggle the plugin list both ways.
- \`/health-check/\` stays visible in request logs while \`/healthz\` remains
  suppressed.
- \`pre-commit run\` clean.